### PR TITLE
Fix sops not decoding secrets

### DIFF
--- a/os/sops.nix
+++ b/os/sops.nix
@@ -11,7 +11,7 @@ in
   sops = {
     defaultSopsFile = self + /secrets/system.yaml;
     age = {
-      keyFile = "/root/secret/keys.txt";
+      keyFile = "/nix/secret/keys.txt";
       generateKey = false;
     };
     secrets = {


### PR DESCRIPTION
Fixes #7 .

Had to move keys to /nix tree since sops-install-secrets kept running before /persistent and /root/secret were being mounted by zfs.